### PR TITLE
Fix network in Host Metrics dashboard

### DIFF
--- a/hostmetrics/Host Metrics.dashboard.json
+++ b/hostmetrics/Host Metrics.dashboard.json
@@ -212,7 +212,7 @@
       "queryType": "promql",
       "queries": [
         {
-          "query": "avg by(host_name) (irate(system_network_io{direction=\"receive\" }[5m]))",
+          "query": "sum by(host_name) (irate(system_network_io{direction=\"receive\" }[5m]))",
           "customQuery": true,
           "fields": {
             "stream": "bytes_committed",
@@ -258,7 +258,7 @@
       "queryType": "promql",
       "queries": [
         {
-          "query": "avg by(host_name) (irate(system_network_io{direction=\"transmit\" }[5m]))",
+          "query": "sum by(host_name) (irate(system_network_io{direction=\"transmit\" }[5m]))",
           "customQuery": true,
           "fields": {
             "stream": "bytes_committed",


### PR DESCRIPTION
Originally it was doing `avg by` so it takes all interfaces and averages them - and in the simplest case show `(lo + eth0)/2`, which is wrong from any point of view I guess. So let's just show `(lo + eth0)`. Maybe it's better to split by interfaces, it can be discussed